### PR TITLE
Please add Jiyugaoka

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -19,5 +19,12 @@
     "サブドメイン": "mino",
     "CNAME": "mino-iemeshi.netlify.app",
     "GitHub": "https://github.com/rnsk/iemeshi"
+  },
+  {
+    "都道府県名": "東京都",
+    "地域名": "自由が丘",
+    "サブドメイン": "jiyugaoka",
+    "CNAME": "jiyugaoka-iemeshi.netlify.app",
+    "GitHub": "https://github.com/atachibana/iemeshi"
   }
 ]


### PR DESCRIPTION
自由が丘 (jiyugaoka) を加えてください。

なお現段階で Netlify のドメイン指定に何を指定しても「Another site is already using this domain」と言われて先へ進めないのですが、何か間違っているのでしょうか?

手順
1. 左メニューで Domain Management -> Domains
2. Add Custom Domain
3. jiyugaoka.iemeshi.jp と入力し、Verify
4. Yes, add domain
5. Verify again 
<img width="1237" alt="3" src="https://user-images.githubusercontent.com/8876600/80731295-ac6c3b80-8b45-11ea-8004-af547123c8f6.png">
